### PR TITLE
Fix bug in NewMediaItem API

### DIFF
--- a/google_photos_library_api/model.py
+++ b/google_photos_library_api/model.py
@@ -237,7 +237,7 @@ class SimpleMediaItem:
 class NewMediaItem(DataClassDictMixin):
     """New media item to create."""
 
-    simple_media_item: list[SimpleMediaItem] = field(
+    simple_media_item: SimpleMediaItem = field(
         metadata=field_options(alias="simpleMediaItem")
     )
     """Simple media item to create."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -180,9 +180,7 @@ async def test_create_media_items(
     )
     result = await api.create_media_items(
         [
-            NewMediaItem(
-                simple_media_item=[SimpleMediaItem(upload_token="new-upload-token-1")]
-            )
+            NewMediaItem(SimpleMediaItem(upload_token="new-upload-token-1"))
         ]
     )
     assert result == CreateMediaItemsResult(


### PR DESCRIPTION
Update the NewMediaItem to take a single media item as it was mistakenly a list.