### PR TITLE
Exclude non-app created data from APIs

### DIFF
--- a/google_photos_library_api/api.py
+++ b/google_photos_library_api/api.py
@@ -134,19 +134,15 @@ class GooglePhotosLibraryApi:
         if page_token is not None:
             args["pageToken"] = page_token
         if album_id is not None:
-            if album_id is not None:
-                args["albumId"] = album_id
-            return await self._auth.post_json(
-                "v1/mediaItems:search",
-                params={"fields": (fields or LIST_MEDIA_ITEM_FIELDS)},
-                json=args,
-                data_cls=_ListMediaItemResultModel,
-            )
-        return await self._auth.get_json(
-            "v1/mediaItems",
-            params={**args, "fields": (fields or LIST_MEDIA_ITEM_FIELDS)},
+            args["albumId"] = album_id
+        args["filters"] = {"excludeNonAppCreatedData": True}
+        return await self._auth.post_json(
+            "v1/mediaItems:search",
+            params={"fields": (fields or LIST_MEDIA_ITEM_FIELDS)},
+            json=args,
             data_cls=_ListMediaItemResultModel,
         )
+
 
     async def list_albums(
         self,
@@ -179,6 +175,7 @@ class GooglePhotosLibraryApi:
         params: dict[str, Any] = {
             "pageSize": (page_size or DEFAULT_PAGE_SIZE),
             "fields": (fields or LIST_ALBUMS_FIELDS),
+            "excludeNonAppCreatedData": "true",
         }
         if page_token is not None:
             params["pageToken"] = page_token
@@ -201,7 +198,7 @@ class GooglePhotosLibraryApi:
             json=request,
             data_cls=Album,
         )
-    
+
     async def update_album(
         self,
         album: NewAlbum,

--- a/google_photos_library_api/api.py
+++ b/google_photos_library_api/api.py
@@ -143,7 +143,6 @@ class GooglePhotosLibraryApi:
             data_cls=_ListMediaItemResultModel,
         )
 
-
     async def list_albums(
         self,
         page_size: int | None = None,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = google_photos_library_api
-version = 0.11.0
+version = 0.11.1
 description = A python client library for Google Photos Library API
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -296,10 +296,7 @@ async def test_list_media_items_paging(
     assert requests[0].query_string == f"fields={expected_fields}"
     assert requests[1].method == "POST"
     assert requests[1].path == "/path-prefix/v1/mediaItems:search"
-    assert (
-        requests[1].query_string
-        == f"fields={expected_fields}"
-    )
+    assert requests[1].query_string == f"fields={expected_fields}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This improves performance by limiting data to just what is requested in scope.